### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         include:
         # - os: macos-latest
         #   python-version: "3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
   "Operating System :: MacOS",
   "Operating System :: POSIX",
   "Operating System :: Microsoft :: Windows",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -34,7 +33,7 @@ keywords = ["audio", "dsp", "music composition", "scsynth", "supercollider", "sy
 license = {text = "MIT"}
 name = "supriya"
 readme = "README.md"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 
 [project.optional-dependencies]
 docs = [
@@ -79,7 +78,7 @@ repository = "https://github.com/supriya-project/supriya"
 target-version = ["py312"]
 
 [tool.cibuildwheel]
-build = "cp38-* cp39-* cp310-* cp311-* cp312-*"
+build = "cp39-* cp310-* cp311-* cp312-*"
 test-command = [
   "python -c 'from supriya.contexts import shm; print(shm.__file__)'",
   "python -c 'from supriya.utils._intervals import IntervalTreeDriverEx'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ docs = [
   "librosa",
   "matplotlib",
   "mypy",
+  "soxr==0.4.0b1", # https://github.com/librosa/librosa/issues/1831#issuecomment-2176274560
   "sphinx-immaterial",
   "sphinxext-opengraph",
 ]
@@ -65,6 +66,7 @@ test = [
   "pytest-mock",
   "pytest-rerunfailures",
   "setuptools; python_version >= '3.12'",
+  "soxr==0.4.0b1", # https://github.com/librosa/librosa/issues/1831#issuecomment-2176274560
   "types-PyYAML",
   "types-docutils",
 ]

--- a/tests/book/test_ext_book.py
+++ b/tests/book/test_ext_book.py
@@ -3,7 +3,6 @@ import os
 import pathlib
 import platform
 import shutil
-import sys
 
 import pytest
 import uqbar.io
@@ -63,7 +62,6 @@ def test_sphinx_book_html(caplog, app, status, warning, rm_dirs):
     assert len(plot_svg_paths) == 1
 
 
-@pytest.mark.skipif(sys.version_info < (3, 9), reason="Sphinx paths broken in 3.8")
 @pytest.mark.sphinx("text", testroot="book")
 def test_sphinx_book_text(app, status, warning, rm_dirs):
     app.build()


### PR DESCRIPTION
I'm tired...
- of not being able to subscript classes for type annotations
- of needing to use `Optional` everywhere instead of `type | None`
- of needing to use Dict, List, Set instead of dict, list, set

I'll have to wait for `type | None` until we get to 3.10, but we can knock the others out.