### PR TITLE
Pin SuperCollider to 3.13

### DIFF
--- a/.github/actions/supercollider/action.yml
+++ b/.github/actions/supercollider/action.yml
@@ -122,7 +122,7 @@ runs:
       if: runner.os == 'Linux'
       run: |
         cd /tmp/supercollider/build
-        sudo make install -j2
+        sudo make install -j2 > build.log || cat build.log
         mkdir -p /home/runner/.local/share/SuperCollider/synthdefs
       shell: bash
     - name: '[macOS] Install'

--- a/.github/actions/supercollider/action.yml
+++ b/.github/actions/supercollider/action.yml
@@ -74,6 +74,7 @@ runs:
           fftw \
           jack \
           portaudio
+        brew install --cask blackhole-16ch
       shell: bash
     - name: '[Linux] Configure'
       if: runner.os == 'Linux'

--- a/.github/actions/supercollider/action.yml
+++ b/.github/actions/supercollider/action.yml
@@ -145,6 +145,9 @@ runs:
         sudo -E su ${USER} -c "jackd -r -ddummy -r44100 -p1024" &
         sleep 1
       shell: bash
+    - name: '[macOS] Debug Jack'
+      run: system_profiler -json | jq .SPAudioDataType
+      shell: bash
     - name: Sanity-check scsynth
       run: |
         echo "Sanity-checking scsynth..."

--- a/.github/actions/supercollider/action.yml
+++ b/.github/actions/supercollider/action.yml
@@ -141,9 +141,9 @@ runs:
         if [ "$RUNNER_OS" == "Linux" ]; then
           sudo usermod -a -G audio ${USER}
         fi
-        sleep 1
+        sleep 5
         sudo -E su ${USER} -c "jackd -r -ddummy -r44100 -p1024" &
-        sleep 1
+        sleep 5
       shell: bash
     - name: '[macOS] Debug Jack'
       if: runner.os == 'macOS'

--- a/.github/actions/supercollider/action.yml
+++ b/.github/actions/supercollider/action.yml
@@ -4,7 +4,7 @@ inputs:
   branch:
     description: SuperCollider branch
     required: false
-    default: Version-3.13.0
+    default: develop
   origin:
     description: SuperCollider repo origin
     required: false

--- a/.github/actions/supercollider/action.yml
+++ b/.github/actions/supercollider/action.yml
@@ -16,15 +16,6 @@ runs:
       id: current-date
       run: echo "stamp=$(date '+%Y-%m-%d')" >> $GITHUB_OUTPUT
       shell: bash
-    - name: Clone SuperCollider
-      run: |
-        git clone \
-          --quiet \
-          --recursive \
-          --branch ${{ inputs.branch }} \
-          ${{ inputs.origin }} \
-          /tmp/supercollider
-      shell: bash
     - name: '[macOS] Cache Homebrew'
       id: cache-homebrew
       if: runner.os == 'macOS'
@@ -75,6 +66,31 @@ runs:
           jack \
           portaudio
           # brew install --cask blackhole-16ch
+      shell: bash
+    - name: Setup Jack
+      run: |
+        echo "Setting up Jack..."
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          sudo usermod -a -G audio ${USER}
+        fi
+        sleep 5
+        echo "Starting Jack..."
+        sudo -E su ${USER} -c "jackd -r -ddummy -r44100 -p1024" &
+        echo "Waiting for Jack..."
+        sleep 5
+      shell: bash
+    - name: '[macOS] Debug Jack'
+      if: runner.os == 'macOS'
+      run: system_profiler -json | jq .SPAudioDataType
+      shell: bash
+    - name: Clone SuperCollider
+      run: |
+        git clone \
+          --quiet \
+          --recursive \
+          --branch ${{ inputs.branch }} \
+          ${{ inputs.origin }} \
+          /tmp/supercollider
       shell: bash
     - name: '[Linux] Configure'
       if: runner.os == 'Linux'
@@ -134,20 +150,6 @@ runs:
       shell: bash
     - name: Debug ccache
       run: ccache --show-stats --show-config
-      shell: bash
-    - name: Setup Jack
-      run: |
-        echo "Setting up Jack..."
-        if [ "$RUNNER_OS" == "Linux" ]; then
-          sudo usermod -a -G audio ${USER}
-        fi
-        sleep 5
-        sudo -E su ${USER} -c "jackd -r -ddummy -r44100 -p1024" &
-        sleep 5
-      shell: bash
-    - name: '[macOS] Debug Jack'
-      if: runner.os == 'macOS'
-      run: system_profiler -json | jq .SPAudioDataType
       shell: bash
     - name: Sanity-check scsynth
       run: |

--- a/.github/actions/supercollider/action.yml
+++ b/.github/actions/supercollider/action.yml
@@ -74,7 +74,7 @@ runs:
           fftw \
           jack \
           portaudio
-        brew install --cask blackhole-16ch
+          # brew install --cask blackhole-16ch
       shell: bash
     - name: '[Linux] Configure'
       if: runner.os == 'Linux'

--- a/.github/actions/supercollider/action.yml
+++ b/.github/actions/supercollider/action.yml
@@ -122,7 +122,7 @@ runs:
       if: runner.os == 'Linux'
       run: |
         cd /tmp/supercollider/build
-        sudo make install -j2 > build.log || cat build.log
+        sudo make install -j2 > build.log || (cat build.log && false)
         mkdir -p /home/runner/.local/share/SuperCollider/synthdefs
       shell: bash
     - name: '[macOS] Install'

--- a/.github/actions/supercollider/action.yml
+++ b/.github/actions/supercollider/action.yml
@@ -146,6 +146,7 @@ runs:
         sleep 1
       shell: bash
     - name: '[macOS] Debug Jack'
+      if: runner.os == 'macOS'
       run: system_profiler -json | jq .SPAudioDataType
       shell: bash
     - name: Sanity-check scsynth

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   SC_ORIGIN: https://github.com/supercollider/supercollider.git
-  SC_BRANCH: develop
+  SC_BRANCH: Version-3.13.0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/tests/contexts/test_Server_misc.py
+++ b/tests/contexts/test_Server_misc.py
@@ -106,16 +106,17 @@ async def test_query_version(context):
     stdout = completed_subprocess.stdout
     line = completed_subprocess.stdout.splitlines()[0]
     print(stdout, line)
-    (program_name, major, minor, patch, branch, commit) = re.match(
-        r"(\w+) (\d+)\.(\d+)(\.[\w-]+) \(Built from branch '([\W\w]+)' \[([\W\w]+)\]\)",
+    groups = re.match(
+        r"(\w+) (\d+)\.(\d+)(\.[\w-]+) \(Built from (?:branch|tag) '([\W\w]+)' \[([\W\w]+)\]\)",
         line,
     ).groups()
+    program_name, major, minor, patch, ref, commit = groups
     expected_info = VersionInfo(
         program_name=program_name,
         major=int(major),
         minor=int(minor),
         patch=patch,
-        branch=branch,
+        branch=ref,
         commit=commit,
     )
     assert await get(context.query_version()) == expected_info


### PR DESCRIPTION
GHA's jack has been cranky without installing additional audio devices.

I attempted to fix this by installing BlackHole, but per https://github.com/ExistentialAudio/BlackHole/discussions/638#discussioncomment-9101745 HomeBrew's version of BlackHole is out-of-date.

Edit: Just seems like jack fails to create the null audio device randomly on OSX. We can just re-run those tests until they work 🤷‍♀️ 