### PR TITLE
Skip macOS builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,8 +108,8 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
-        - os: macos-latest
-          python-version: "3.12"
+        # - os: macos-latest
+        #   python-version: "3.12"
         - os: windows-latest
           python-version: "3.12"
     timeout-minutes: 45


### PR DESCRIPTION
SuperCollider is currently failing to build on macOS. Let's skip so other PRs can go green while we figure out what's wrong.