### PR TITLE
Add Python 3.13 to GHA build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13-dev"]
         include:
         - os: macos-12
           python-version: "3.12"
@@ -118,9 +118,9 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
-        cache: pip
         cache-dependency-path: "**/pyproject.toml"
+        cache: pip
+        python-version: ${{ matrix.python-version }}
     - name: Upgrade pip
       run: python3 -m pip install -U pip
     - name: Install Supriya


### PR DESCRIPTION
As usual, we're waiting on librosa, which is waiting on numba.

Aside: would be great to have access to librosa's soundfile loading and soundfile graphing tools without needing to block everything on the numba dependency (which, by definition, always has a significant lag against the latest Python version while they adapt to the bytecode changes).