### PR TITLE
Make some Clock methods private

### DIFF
--- a/supriya/clocks/asynchronous.py
+++ b/supriya/clocks/asynchronous.py
@@ -119,7 +119,7 @@ class AsyncClock(BaseClock):
             pass
 
     async def _wait_for_moment_async(self, offline: bool = False) -> Optional[Moment]:
-        current_time = self.get_current_time()
+        current_time = self._get_current_time()
         next_time = self._event_queue.peek().seconds
         logger.debug(
             f"[{self.name}] ... Waiting for next moment at {next_time} from {current_time}"
@@ -131,7 +131,7 @@ class AsyncClock(BaseClock):
                 return None
             self._process_command_deque()
             next_time = self._event_queue.peek().seconds
-            current_time = self.get_current_time()
+            current_time = self._get_current_time()
             self._event.clear()
         return self._seconds_to_moment(current_time)
 

--- a/supriya/clocks/offline.py
+++ b/supriya/clocks/offline.py
@@ -16,6 +16,11 @@ class OfflineClock(BaseClock):
 
     ### SCHEDULING METHODS ###
 
+    def _get_current_time(self) -> float:
+        if not self._is_running:
+            return 0.0
+        return self._state.previous_seconds
+
     def _perform_callback_event(
         self, event: CallbackEvent, current_moment: Moment, desired_moment: Moment
     ) -> None:
@@ -66,11 +71,6 @@ class OfflineClock(BaseClock):
 
     ### PUBLIC METHODS ###
 
-    def get_current_time(self) -> float:
-        if not self._is_running:
-            return 0.0
-        return self._state.previous_seconds
-
     def start(
         self,
         initial_time: Optional[float] = None,
@@ -102,6 +102,12 @@ class OfflineClock(BaseClock):
 
 
 class AsyncOfflineClock(AsyncClock):
+
+    def _get_current_time(self) -> float:
+        if not self._is_running:
+            return 0.0
+        return self._state.previous_seconds
+
     async def _run_async(self, offline: bool = False) -> None:
         logger.debug(f"[{self.name}] Coroutine start")
         self._process_command_deque(first_run=True)
@@ -136,8 +142,3 @@ class AsyncOfflineClock(AsyncClock):
         self._process_command_deque()
         self._event.clear()
         return True
-
-    def get_current_time(self) -> float:
-        if not self._is_running:
-            return 0.0
-        return self._state.previous_seconds

--- a/supriya/clocks/threaded.py
+++ b/supriya/clocks/threaded.py
@@ -52,7 +52,7 @@ class Clock(BaseClock):
         logger.debug(f"[{self.name}] Terminating")
 
     def _wait_for_moment(self, offline: bool = False) -> Optional[Moment]:
-        current_time = self.get_current_time()
+        current_time = self._get_current_time()
         next_time = self._event_queue.peek().seconds
         logger.debug(
             f"[{self.name}] ... Waiting for next moment at {next_time} from {current_time}"
@@ -64,7 +64,7 @@ class Clock(BaseClock):
                 return None
             self._process_command_deque()
             next_time = self._event_queue.peek().seconds
-            current_time = self.get_current_time()
+            current_time = self._get_current_time()
             self._event.clear()
         return self._seconds_to_moment(current_time)
 

--- a/tests/clocks/test_AsyncClock.py
+++ b/tests/clocks/test_AsyncClock.py
@@ -29,7 +29,7 @@ async def clock(mocker, monkeypatch):
     clock = AsyncClock()
     clock.slop = 0.01
     monkeypatch.setattr(AsyncClock, "_wait_for_event_async", wait_for_event)
-    mock_time = mocker.patch.object(AsyncClock, "get_current_time")
+    mock_time = mocker.patch.object(AsyncClock, "_get_current_time")
     mock_time.return_value = 0.0
     yield clock
     await clock.stop()
@@ -56,7 +56,7 @@ def callback(
 
 async def set_time_and_check(time_to_advance, clock, store):
     logger.info(f"Setting time to {time_to_advance}")
-    clock.get_current_time.return_value = time_to_advance
+    clock._get_current_time.return_value = time_to_advance
     clock._event.set()
     await asyncio.sleep(0.01)
     moments = []
@@ -474,10 +474,10 @@ async def test_reschedule_earlier(clock):
     assert await set_time_and_check(0.5, clock, store) == []
     event_id = clock.cue(callback, quantization="1M", args=[store], kwargs={"limit": 0})
     await asyncio.sleep(0)
-    assert clock.peek().seconds == 2.0
+    assert clock._peek().seconds == 2.0
     clock.reschedule(event_id, schedule_at=0.5)
     await asyncio.sleep(0)
-    assert clock.peek().seconds == 1.0
+    assert clock._peek().seconds == 1.0
     assert await set_time_and_check(2.0, clock, store) == [
         (["4/4", 120.0], [2, 0.0, 1.0, 2.0], [1, 0.5, 0.5, 1.0])
     ]
@@ -490,10 +490,10 @@ async def test_reschedule_later(clock):
     assert await set_time_and_check(0.5, clock, store) == []
     event_id = clock.cue(callback, quantization="1M", args=[store], kwargs={"limit": 0})
     await asyncio.sleep(0)
-    assert clock.peek().seconds == 2.0
+    assert clock._peek().seconds == 2.0
     clock.reschedule(event_id, schedule_at=1.5)
     await asyncio.sleep(0)
-    assert clock.peek().seconds == 3.0
+    assert clock._peek().seconds == 3.0
     assert await set_time_and_check(3.0, clock, store) == [
         (["4/4", 120.0], [2, 0.5, 1.5, 3.0], [2, 0.5, 1.5, 3.0])
     ]

--- a/tests/clocks/test_Clock.py
+++ b/tests/clocks/test_Clock.py
@@ -15,7 +15,7 @@ repeat_count = 5
 def clock(mocker):
     clock = Clock()
     clock.slop = 0.001
-    mock = mocker.patch.object(Clock, "get_current_time")
+    mock = mocker.patch.object(Clock, "_get_current_time")
     mock.return_value = 0.0
     yield clock
     clock.stop()
@@ -41,7 +41,7 @@ def callback(
 
 
 def set_time_and_check(time_to_advance, clock, store):
-    clock.get_current_time.return_value = time_to_advance
+    clock._get_current_time.return_value = time_to_advance
     multiplier = 4
     if platform.system() == "Windows":
         multiplier = 40  # Windows CI is really slow
@@ -458,10 +458,10 @@ def test_reschedule_earlier(clock):
     assert set_time_and_check(0.5, clock, store) == []
     event_id = clock.cue(callback, quantization="1M", args=[store], kwargs={"limit": 0})
     time.sleep(clock.slop * 2)
-    assert clock.peek().seconds == 2.0
+    assert clock._peek().seconds == 2.0
     clock.reschedule(event_id, schedule_at=0.5)
     time.sleep(clock.slop * 2)
-    assert clock.peek().seconds == 1.0
+    assert clock._peek().seconds == 1.0
     assert set_time_and_check(2.0, clock, store) == [
         (["4/4", 120.0], [2, 0.0, 1.0, 2.0], [1, 0.5, 0.5, 1.0])
     ]
@@ -474,10 +474,10 @@ def test_reschedule_later(clock):
     assert set_time_and_check(0.5, clock, store) == []
     event_id = clock.cue(callback, quantization="1M", args=[store], kwargs={"limit": 0})
     time.sleep(clock.slop * 2)
-    assert clock.peek().seconds == 2.0
+    assert clock._peek().seconds == 2.0
     clock.reschedule(event_id, schedule_at=1.5)
     time.sleep(clock.slop * 2)
-    assert clock.peek().seconds == 3.0
+    assert clock._peek().seconds == 3.0
     assert set_time_and_check(3.0, clock, store) == [
         (["4/4", 120.0], [2, 0.5, 1.5, 3.0], [2, 0.5, 1.5, 3.0])
     ]


### PR DESCRIPTION
The following methods shouldn't be part of the public interface:
- `get_current_time()` -> `_get_current_time()`
- `peek()` -> `_peek()`
- `quantization_to_beats()` -> `_quantization_to_beats()`