### PR TITLE
Add (Async)?OfflineClock.at() context manager

### DIFF
--- a/supriya/clocks/asynchronous.py
+++ b/supriya/clocks/asynchronous.py
@@ -104,10 +104,10 @@ class AsyncClock(BaseClock):
         while self._is_running:
             logger.debug(f"[{self.name}] Loop start")
             if not await self._wait_for_queue_async():
-                return
+                break
             try:
                 if (current_moment := await self._wait_for_moment_async()) is None:
-                    return
+                    break
             except queue.Empty:
                 continue
             current_moment = await self._perform_events_async(current_moment)

--- a/supriya/clocks/core.py
+++ b/supriya/clocks/core.py
@@ -283,6 +283,9 @@ class BaseClock:
     def _get_current_time(self) -> float:
         return time.time()
 
+    def _get_initial_time(self) -> float:
+        return self._get_current_time()
+
     def _get_schedule_point(
         self, schedule_at: float, time_unit: TimeUnit
     ) -> Tuple[float, Optional[float], Optional[int]]:
@@ -683,8 +686,9 @@ class BaseClock:
     ) -> None:
         if self._is_running:
             raise RuntimeError("Already started")
+        # TODO: This if block only makes sense in online clocks
         if initial_time is None:
-            initial_time = self._get_current_time()
+            initial_time = self._get_initial_time()
         self._state = ClockState(
             beats_per_minute=beats_per_minute or self._state.beats_per_minute,
             initial_seconds=initial_time,

--- a/supriya/clocks/offline.py
+++ b/supriya/clocks/offline.py
@@ -1,6 +1,7 @@
 import logging
 import queue
-from typing import Generator, Optional, Tuple
+from contextlib import asynccontextmanager, contextmanager
+from typing import AsyncGenerator, Generator, Optional, Tuple
 
 from .asynchronous import AsyncClock
 from .core import BaseClock, CallbackEvent, ClockContext, Moment, TimeUnit
@@ -13,18 +14,13 @@ class OfflineClock(BaseClock):
     An offline clock.
     """
 
-    ### INITIALIZER ###
-
-    def __init__(self) -> None:
-        super().__init__()
-        self._generator: Optional[Generator[bool, None, None]] = None
-
     ### SCHEDULING METHODS ###
 
     def _get_current_time(self) -> float:
-        if not self._is_running:
-            return 0.0
         return self._state.previous_seconds
+
+    def _get_initial_time(self) -> float:
+        return self._state.initial_seconds
 
     def _perform_callback_event(
         self, event: CallbackEvent, current_moment: Moment, desired_moment: Moment
@@ -44,16 +40,16 @@ class OfflineClock(BaseClock):
             delta, time_unit = result
         self._process_callback_event_result(desired_moment, event, delta, time_unit)
 
-    def _run(self, offline: bool = False) -> Generator[bool, None, None]:
+    def _run(self, offline: bool = False):
         logger.debug(f"[{self.name}] Thread start")
         self._process_command_deque(first_run=True)
         while self._is_running and self._event_queue.qsize():
             logger.debug(f"[{self.name}] Loop start")
             if not self._wait_for_queue():
-                return
+                break
             try:
                 if (current_moment := self._wait_for_moment()) is None:
-                    return
+                    break
             except queue.Empty:
                 continue
             current_moment = self._perform_events(current_moment)
@@ -62,7 +58,6 @@ class OfflineClock(BaseClock):
                 previous_offset=current_moment.offset,
             )
         logger.debug(f"[{self.name}] Terminating")
-        yield False
         self._stop()
 
     def _wait_for_moment(self, offline: bool = False) -> Optional[Moment]:
@@ -75,6 +70,24 @@ class OfflineClock(BaseClock):
         return True
 
     ### PUBLIC METHODS ###
+
+    @contextmanager
+    def at(
+        self,
+        initial_time: Optional[float] = None,
+        initial_offset: float = 0.0,
+        initial_measure: int = 1,
+        beats_per_minute: Optional[float] = None,
+        time_signature: Optional[Tuple[int, int]] = None,
+    ) -> Generator["OfflineClock", None, None]:
+        yield self
+        self.start(
+            initial_time=initial_time,
+            initial_offset=initial_offset,
+            initial_measure=initial_measure,
+            beats_per_minute=beats_per_minute,
+            time_signature=time_signature,
+        )
 
     def start(
         self,
@@ -91,27 +104,21 @@ class OfflineClock(BaseClock):
             beats_per_minute=beats_per_minute,
             time_signature=time_signature,
         )
-        self._generator = self._run()
-        if not next(self._generator):
-            self._stop()
+        self._run()
 
     def stop(self) -> None:
-        if not self._stop():
-            return
-        if self._generator is not None:
-            while True:
-                try:
-                    next(self._generator)
-                except StopIteration:
-                    pass
+        return
 
 
 class AsyncOfflineClock(AsyncClock):
 
+    ### SCHEDULING METHODS ###
+
     def _get_current_time(self) -> float:
-        if not self._is_running:
-            return 0.0
         return self._state.previous_seconds
+
+    def _get_initial_time(self) -> float:
+        return self._state.initial_seconds
 
     async def _run_async(self, offline: bool = False) -> None:
         logger.debug(f"[{self.name}] Coroutine start")
@@ -119,10 +126,10 @@ class AsyncOfflineClock(AsyncClock):
         while self._is_running and self._event_queue.qsize():
             logger.debug(f"[{self.name}] Loop start")
             if not await self._wait_for_queue_async():
-                return
+                break
             try:
                 if (current_moment := await self._wait_for_moment_async()) is None:
-                    return
+                    break
             except queue.Empty:
                 continue
             current_moment = await self._perform_events_async(current_moment)
@@ -147,3 +154,43 @@ class AsyncOfflineClock(AsyncClock):
         self._process_command_deque()
         self._event.clear()
         return True
+
+    ### PUBLIC METHODS ###
+
+    @asynccontextmanager
+    async def at(
+        self,
+        initial_time: Optional[float] = None,
+        initial_offset: float = 0.0,
+        initial_measure: int = 1,
+        beats_per_minute: Optional[float] = None,
+        time_signature: Optional[Tuple[int, int]] = None,
+    ) -> AsyncGenerator["AsyncOfflineClock", None]:
+        yield self
+        await self.start(
+            initial_time=initial_time,
+            initial_offset=initial_offset,
+            initial_measure=initial_measure,
+            beats_per_minute=beats_per_minute,
+            time_signature=time_signature,
+        )
+
+    async def start(
+        self,
+        initial_time: Optional[float] = None,
+        initial_offset: float = 0.0,
+        initial_measure: int = 1,
+        beats_per_minute: Optional[float] = None,
+        time_signature: Optional[Tuple[int, int]] = None,
+    ) -> None:
+        self._start(
+            initial_time=initial_time,
+            initial_offset=initial_offset,
+            initial_measure=initial_measure,
+            beats_per_minute=beats_per_minute,
+            time_signature=time_signature,
+        )
+        await self._run_async()
+
+    async def stop(self) -> None:
+        return

--- a/supriya/clocks/threaded.py
+++ b/supriya/clocks/threaded.py
@@ -34,13 +34,13 @@ class Clock(BaseClock):
         while self._is_running:
             logger.debug(f"[{self.name}] Loop start")
             if not self._wait_for_queue():
-                return
+                break
             try:
                 current_moment = self._wait_for_moment()
             except queue.Empty:
                 continue
             if current_moment is None:
-                return
+                break
             current_moment = self._perform_events(current_moment)
             self._state = self._state._replace(
                 previous_seconds=current_moment.seconds,
@@ -49,6 +49,7 @@ class Clock(BaseClock):
             if not offline:
                 self._event.wait(timeout=self._slop)
         logger.debug(f"[{self.name}] Terminating")
+        self._stop()
 
     def _wait_for_moment(self, offline: bool = False) -> Optional[Moment]:
         current_time = self._get_current_time()


### PR DESCRIPTION
A utility for entering a context, letting user code queue-up patterns, then running the offline clock once the context exits.