### PR TITLE
Implement NoteEvent.rest for resting

### DIFF
--- a/supriya/osc/utils.py
+++ b/supriya/osc/utils.py
@@ -1,0 +1,38 @@
+import pprint
+from typing import Sequence
+
+from ..ugens import decompile_synthdefs
+from .messages import OscBundle, OscMessage
+
+
+def format_messages(messages: Sequence[OscBundle | OscMessage]) -> str:
+    """
+    Format a sequence of OSC messages as a string.
+
+    Provides a more concise means of verifying OSC contents in the test suite
+    than comparing the messages directly.
+    """
+
+    def sanitize(list_):
+        for i, x in enumerate(list_):
+            if isinstance(x, bytes):
+                try:
+                    decompiled = decompile_synthdefs(x)
+                    list_[i] = decompiled[0] if len(decompiled) == 1 else decompiled
+                except Exception:
+                    pass
+            elif isinstance(x, list):
+                sanitize(x)
+        return list_
+
+    lines: list[str] = []
+    for message in messages:
+        sanitized = sanitize(message.to_list())
+        formatted = pprint.pformat(sanitized, width=120)
+        for i, line in enumerate(formatted.splitlines()):
+            if i == 0:
+                prefix = "-"
+            else:
+                prefix = " "
+            lines.append(f"{prefix} {line}")
+    return "\n".join(lines)


### PR DESCRIPTION
This PR adds a new NoteEvent.rest property which treats the performance of the note as a silence. Works with notes generated by both EventPattern and MonoEventPattern.

For example:

```
MonoEventPattern(
    frequency=SequencePattern([444, 555, 666, 777]),
    rest=SequencePattern([False, False, True, False]),
)
```